### PR TITLE
Improve mobile layout (no-scroll) and add cyberpunk theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,9 +18,23 @@
             --card-border: #7b2cff;
             --neon-shadow: 0 0 16px rgba(0, 231, 255, 0.45);
             --chrome: rgba(12, 4, 28, 0.88);
+
+            /* Layout offsets used in cell sizing (documented for maintainability). */
+            /* Total horizontal non-board space (padding/margins/etc.) */
+            --board-horizontal-chrome: 48px;
+            /* Horizontal gap between board and surrounding content */
+            --board-horizontal-gap: 20px;
+            /* Extra horizontal safety margin (e.g., scrollbar/reserved space) */
+            --board-horizontal-reserve: 28px;
+            /* Vertical space taken by scoreboard/banner and surrounding chrome */
+            --vertical-chrome-height: 260px;
+
             --cell-size: min(
-                calc((100vw - 48px - 20px - 28px) / 10),
-                max(1px, calc((100dvh - 260px) / 10)),
+                calc(
+                    (100vw - var(--board-horizontal-chrome) - var(--board-horizontal-gap) - var(--board-horizontal-reserve))
+                    / 10
+                ),
+                max(1px, calc((100dvh - var(--vertical-chrome-height)) / 10)),
                 62px
             );
             --axis-size: max(24px, calc(var(--cell-size) * 0.62));


### PR DESCRIPTION
### Motivation
- Provide a mobile-friendly board that fits a phone viewport without horizontal or vertical scrolling. 
- Restyle the UI with a cypherpunk/cyberpunk visual language (neon accents, gradients and glowing effects) to give the board a distinctive theme. 
- Remove visual white bars and improve input rendering on mobile while preserving accessibility focus states. 

### Description
- Introduces CSS viewport-driven sizing variables (`--cell-size`, `--axis-size`) and switches the grid to fixed cell sizing so the 10x10 board fits within the viewport, and uses `height: 100dvh; overflow: hidden;` to avoid scrolling. 
- Replaces the original palette with a neon/cyberpunk palette via new CSS variables, gradients, neon borders/shadows, and updated button/label styles. 
- Makes grid/header inputs transparent and adjusts typography/spacing with `clamp()` and responsive media rules to keep content legible on small screens. 
- Adds non-empty placeholder `img` `src` values for team logos so HTML linting passes and ensures runtime API data still overwrites them. 

### Testing
- Ran `npx --yes htmlhint index.html` which completed with no errors. 
- Ran `git diff --check` which reported no whitespace/merge issues. 
- Served the site with `python3 -m http.server 4173` and validated with a Playwright script that recorded `scrollHeight === innerHeight` for a 390x844 viewport and captured a mobile screenshot. 
- Attempted `tidy -qe index.html` and `xmllint --html --noout index.html` but those tools were not available in the environment. 
- Attempted `python -m py_compile index.html` which is not applicable to HTML and did not succeed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698967d4b5f483318e688fda27845904)