### PR TITLE
Tighten grid spacing and strengthen square/header borders

### DIFF
--- a/index.html
+++ b/index.html
@@ -114,7 +114,7 @@
             display: grid;
             grid-template-columns: var(--axis-size) repeat(10, var(--cell-size));
             grid-auto-rows: var(--cell-size);
-            gap: 4px;
+            gap: 2px;
         }
 
         /* --- Header & Inputs (Fixing White Bars) --- */
@@ -126,10 +126,12 @@
             align-items: center;
             justify-content: center;
             height: var(--cell-size);
-            border-radius: 10px;
+            border-radius: 8px;
             position: relative;
-            border: 1px solid rgba(0, 231, 255, 0.35);
-            box-shadow: inset 0 0 10px rgba(0, 231, 255, 0.12);
+            border: 2px solid rgba(0, 231, 255, 0.6);
+            box-shadow:
+                inset 0 0 10px rgba(0, 231, 255, 0.2),
+                0 0 6px rgba(0, 231, 255, 0.2);
         }
 
         /* CRITICAL FIX: Make grid inputs transparent - scoped to grid only */
@@ -160,9 +162,11 @@
             display: flex;
             align-items: center;
             justify-content: center;
-            border-radius: 12px;
-            border: 1px solid rgba(123, 44, 255, 0.45);
-            box-shadow: inset 0 0 12px rgba(0, 0, 0, 0.35);
+            border-radius: 8px;
+            border: 2px solid rgba(123, 44, 255, 0.7);
+            box-shadow:
+                inset 0 0 12px rgba(0, 0, 0, 0.35),
+                0 0 8px rgba(123, 44, 255, 0.2);
             backdrop-filter: blur(8px) saturate(140%);
         }
         .square input {


### PR DESCRIPTION
### Motivation
- Reduce spacing so the squares sit closer together and present a tighter grid layout.
- Make header and square borders more defined and higher-contrast so cells read better against the background.

### Description
- Reduced the grid gap from `4px` to `2px` in `index.html` to bring cells closer together.
- Tightened corner radii on the header and squares from `10px/12px` to `8px` to create a more compact look.
- Increased header and square border thickness to `2px` and bumped border opacity, and added subtle outer glow/shadow for clearer definition.
- Adjusted box-shadow values for both header and squares to improve perceived contrast and separation from the background.

### Testing
- Started a local static server with `python -m http.server 8000` to serve `index.html`, which started successfully.
- Attempted to capture a rendered screenshot using `Playwright`, but the Chromium process crashed (TargetClosedError / SIGSEGV), so visual validation via headless browser failed.
- No unit or integration tests were applicable since this is a static CSS/HTML change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989736e3cdc83319c88017b6fdc69b2)