### PR TITLE
Scale square name fonts to fit cell width

### DIFF
--- a/index.html
+++ b/index.html
@@ -412,8 +412,11 @@
 
             const rootStyles = getComputedStyle(document.documentElement);
             const cellSizeValue = parseFloat(rootStyles.getPropertyValue('--cell-size')) || 60;
-            const maxFontSize = cellSizeValue * 0.32;
-            const minFontSize = Math.max(8, cellSizeValue * 0.18);
+            let maxFontSize = cellSizeValue * 0.32;
+            let minFontSize = Math.max(8, cellSizeValue * 0.18);
+            if (minFontSize > maxFontSize) {
+                minFontSize = maxFontSize;
+            }
             const targetWidth = cellSizeValue - 10;
 
             const canvas = fitTextToCell.canvas || (fitTextToCell.canvas = document.createElement('canvas'));


### PR DESCRIPTION
### Motivation
- Ensure long participant names are readable inside grid squares across different display sizes by dynamically scaling font size. 
- Avoid truncation caused by `text-overflow: ellipsis` so the full name is visible whenever possible.

### Description
- Changed `.square input` `text-overflow` from `ellipsis` to `clip` to prevent forced truncation. 
- Added `fitTextToCell(input, name)` which uses a canvas `measureText` loop to find a font size that fits the available cell width calculated from `--cell-size`. 
- Added `adjustNameFonts()` to run the fitter for every filled square and invoke it after `buildGrid()` and on window `resize` using `requestAnimationFrame`. 
- Applied inline `font-size` to each name input so the computed size is used immediately in the layout.

### Testing
- Launched a local static server with `python -m http.server 8000` and executed a Playwright script to render the page and capture a screenshot at `1200x1400`; the screenshot artifact `artifacts/smaller-font.png` was produced successfully. 
- Verified the grid builds and the name-fitting routine runs on initial render and on window resize during automated rendering; no runtime errors observed in the render run. 
- No unit tests were added or run for this HTML/JS change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698976eb06748331ac61bcf72cf81e0e)