### PR TITLE
Add Clear All button and deterministic unique colors for grid names

### DIFF
--- a/index.html
+++ b/index.html
@@ -321,6 +321,7 @@
     <div class="controls">
         <button onclick="refreshScore()">Refresh Score</button>
         <button id="btn-edit" onclick="toggleEditMode()">✏️ Edit Mode</button>
+        <button onclick="clearGridData()" style="background: #ef4444; border-color: #b91c1c; margin-left: 10px;">🗑️ Clear All</button>
         <button id="btn-export" onclick="exportData()" style="display:none; background-color: #22c55e; border-color: #fff;">💾 Copy Data for GitHub</button>
         <div id="game-setup-panel" style="display:none; margin-top: 15px; padding: 10px; background: #334155; border-radius: 8px;">
             <h4 style="margin: 0 0 10px 0; color: #cbd5e1;">Select a Game</h4>
@@ -389,46 +390,16 @@
 
         let isEditMode = false;
         let currentScore = { home: 0, away: 0 };
-        const namePalette = {
-            'SR': { glass: 'rgba(0, 242, 255, 0.26)', border: 'rgba(74, 252, 255, 0.7)', glow: 'rgba(0, 225, 255, 0.45)', text: '#eaffff' },
-            'EZ': { glass: 'rgba(255, 78, 205, 0.24)', border: 'rgba(255, 139, 230, 0.7)', glow: 'rgba(255, 78, 205, 0.45)', text: '#fff0fb' },
-            'MN': { glass: 'rgba(111, 255, 180, 0.22)', border: 'rgba(144, 255, 201, 0.7)', glow: 'rgba(111, 255, 180, 0.42)', text: '#f0fffa' },
-            'LN': { glass: 'rgba(140, 132, 255, 0.24)', border: 'rgba(181, 174, 255, 0.7)', glow: 'rgba(140, 132, 255, 0.45)', text: '#f5f3ff' },
-            'HN': { glass: 'rgba(255, 179, 71, 0.23)', border: 'rgba(255, 207, 128, 0.72)', glow: 'rgba(255, 179, 71, 0.45)', text: '#fff7ed' },
-            'Cyn': { glass: 'rgba(56, 248, 255, 0.22)', border: 'rgba(132, 252, 255, 0.72)', glow: 'rgba(56, 248, 255, 0.45)', text: '#e9fdff' },
-            'SAU': { glass: 'rgba(255, 109, 98, 0.22)', border: 'rgba(255, 160, 151, 0.7)', glow: 'rgba(255, 109, 98, 0.45)', text: '#fff1f1' },
-            'EM': { glass: 'rgba(180, 133, 255, 0.22)', border: 'rgba(207, 178, 255, 0.7)', glow: 'rgba(180, 133, 255, 0.45)', text: '#f7f3ff' },
-            'Brian B': { glass: 'rgba(91, 255, 244, 0.2)', border: 'rgba(150, 255, 247, 0.7)', glow: 'rgba(91, 255, 244, 0.42)', text: '#effffe' },
-            'Eli': { glass: 'rgba(255, 215, 102, 0.22)', border: 'rgba(255, 233, 170, 0.7)', glow: 'rgba(255, 215, 102, 0.45)', text: '#fff9e6' },
-            'Jamin': { glass: 'rgba(98, 168, 255, 0.22)', border: 'rgba(144, 198, 255, 0.72)', glow: 'rgba(98, 168, 255, 0.45)', text: '#eef6ff' },
-            'ZAN': { glass: 'rgba(255, 115, 220, 0.22)', border: 'rgba(255, 168, 236, 0.7)', glow: 'rgba(255, 115, 220, 0.45)', text: '#fff0fa' },
-            'CuViET': { glass: 'rgba(115, 255, 176, 0.2)', border: 'rgba(168, 255, 212, 0.7)', glow: 'rgba(115, 255, 176, 0.42)', text: '#effff7' },
-            'Gr': { glass: 'rgba(108, 255, 200, 0.2)', border: 'rgba(164, 255, 223, 0.7)', glow: 'rgba(108, 255, 200, 0.42)', text: '#edfffa' },
-            'Jev': { glass: 'rgba(255, 130, 92, 0.22)', border: 'rgba(255, 178, 152, 0.7)', glow: 'rgba(255, 130, 92, 0.45)', text: '#fff2ed' },
-            '🍁': { glass: 'rgba(255, 96, 0, 0.22)', border: 'rgba(255, 162, 96, 0.7)', glow: 'rgba(255, 96, 0, 0.45)', text: '#fff4e6' }
-        };
 
-        function hashName(name) {
+        function getUniqueColor(name) {
+            if (!name || name.trim() === '') return '#334155'; // Default square color
             let hash = 0;
             for (let i = 0; i < name.length; i++) {
-                hash = (hash << 5) - hash + name.charCodeAt(i);
-                hash |= 0;
+                hash = name.charCodeAt(i) + ((hash << 5) - hash);
             }
-            return Math.abs(hash);
-        }
-
-        function getNameStyle(name) {
-            if (namePalette[name]) {
-                return namePalette[name];
-            }
-            const hash = hashName(name);
-            const hue = hash % 360;
-            return {
-                glass: `hsla(${hue}, 90%, 65%, 0.22)`,
-                border: `hsla(${hue}, 95%, 75%, 0.7)`,
-                glow: `hsla(${hue}, 95%, 65%, 0.45)`,
-                text: '#f8fafc'
-            };
+            // Generate a pastel/neon HSL color that looks good on dark backgrounds
+            const h = Math.abs(hash) % 360;
+            return `hsl(${h}, 65%, 25%)`;
         }
 
         function fitTextToCell(input, name) {
@@ -689,6 +660,51 @@ let gridState = ${JSON.stringify(escapedGrid, null, 4)};
             });
         }
 
+
+        function clearGridData() {
+            if (!confirm("⚠️ ARE YOU SURE?\n\nThis will delete ALL names and reset numbers to 0-9.")) {
+                return;
+            }
+
+            // 1. Reset Grid State (Clear Names)
+            gridState = {};
+
+            // 2. Reset Axes to 0-9
+            topAxis = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'];
+            leftAxis = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'];
+
+            // 3. Update DOM - Top Axis
+            for (let i = 0; i < 10; i++) {
+                const input = document.querySelector(`#top-${i} input`);
+                if (input) input.value = topAxis[i];
+            }
+
+            // 4. Update DOM - Left Axis
+            for (let i = 0; i < 10; i++) {
+                const input = document.querySelector(`#left-${i} input`);
+                if (input) input.value = leftAxis[i];
+            }
+
+            // 5. Update DOM - Squares (Clear Value & Color)
+            for (let r = 0; r < 10; r++) {
+                for (let c = 0; c < 10; c++) {
+                    const sq = document.getElementById(`sq-${r}-${c}`);
+                    if (!sq) {
+                        continue;
+                    }
+                    const input = sq.querySelector('input');
+                    if (input) {
+                        input.value = '';
+                        fitTextToCell(input, '');
+                    }
+                    sq.style.backgroundColor = getUniqueColor('');
+                }
+            }
+
+            saveData();
+            alert("Grid Cleared! Don't forget to click 'Edit Mode' -> 'Copy Data' to save these empty changes to GitHub.");
+        }
+
         function buildGrid() {
             const grid = document.getElementById('grid');
             grid.innerHTML = '';
@@ -741,42 +757,33 @@ let gridState = ${JSON.stringify(escapedGrid, null, 4)};
                     square.className = 'square';
                     square.id = `sq-${row}-${col}`;
 
+                    // APPLY INITIAL COLOR based on loaded name
+                    const initialName = gridState[`${row}-${col}`] || '';
+                    square.style.backgroundColor = getUniqueColor(initialName);
+
                     const input = document.createElement('input');
-                    const name = gridState[`${row}-${col}`] || '';
-                    input.value = name;
-                    input.readOnly = true;
-                    input.addEventListener('input', () => {
-                        const nextName = input.value.trim();
-                        if (nextName) {
-                            const style = getNameStyle(nextName);
-                            square.classList.add('name-cell');
-                            square.style.setProperty('--name-glass', style.glass);
-                            square.style.setProperty('--name-border', style.border);
-                            square.style.setProperty('--name-glow', style.glow);
-                            square.style.setProperty('--name-text', style.text);
-                        } else {
-                            square.classList.remove('name-cell');
-                            square.style.removeProperty('--name-glass');
-                            square.style.removeProperty('--name-border');
-                            square.style.removeProperty('--name-glow');
-                            square.style.removeProperty('--name-text');
-                        }
-                        fitTextToCell(input, nextName);
+                    input.value = initialName;
+
+                    // Add event listener to change color AS YOU TYPE
+                    input.oninput = (e) => {
+                        const val = e.target.value;
+                        gridState[`${row}-${col}`] = val;
+                        // Update parent square background color
+                        square.style.backgroundColor = getUniqueColor(val);
+                        fitTextToCell(input, val.trim());
                         if (isEditMode) {
                             saveDataFromDOM();
                         }
-                    });
+                    };
+
+                    // Keep existing readOnly logic check
+                    if (!isEditMode) {
+                        input.readOnly = true;
+                    }
 
                     square.appendChild(input);
-                    if (name) {
-                        const style = getNameStyle(name);
-                        square.classList.add('name-cell');
-                        square.style.setProperty('--name-glass', style.glass);
-                        square.style.setProperty('--name-border', style.border);
-                        square.style.setProperty('--name-glow', style.glow);
-                        square.style.setProperty('--name-text', style.text);
-                    }
                     grid.appendChild(square);
+                    fitTextToCell(input, initialName.trim());
                 }
             }
 


### PR DESCRIPTION
### Motivation
- Provide an easy way to reset the board state (names and axes) with a clear, destructive control. 
- Replace the prior hardcoded name-palette path with a deterministic per-name color so each name has a consistent, unique square background.

### Description
- Added a red `🗑️ Clear All` button next to the `Edit Mode` button that calls `clearGridData()` to perform the reset. 
- Implemented `getUniqueColor(name)` which maps a name string to a deterministic HSL color and returns `#334155` for empty values. 
- Reworked the square creation logic in `buildGrid()` so each square applies an initial color from `getUniqueColor(...)`, updates its color live while typing via `input.oninput`, and preserves the read-only/edit-mode behavior. 
- Added `clearGridData()` which confirms the action, clears `gridState`, resets `topAxis`/`leftAxis` to `0-9`, updates the DOM for headers and squares (clearing values and resetting colors), and persists the cleared state via `saveData()`.

### Testing
- Ran `npx --yes htmlhint index.html` and it completed with no errors. 
- Launched a local static server with `python3 -m http.server 4173` and executed a Playwright smoke script that confirmed the `Clear All` button exists and that a square's background changes when typing a name, and the script produced a screenshot. 
- All automated checks (HTMLHint and the Playwright smoke test) succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989ab03a1708331bc9897ed20c8b518)